### PR TITLE
Updating ensembl repos WBPS is downloading prior a new release.

### DIFF
--- a/parasite/scripts/production/new_release_setup/checkout_git_repos.sh
+++ b/parasite/scripts/production/new_release_setup/checkout_git_repos.sh
@@ -44,6 +44,6 @@ checkout_ensembl_branch ensembl-hive version/2.6
 checkout_ensembl_branch eg-pipelines master EnsemblGenomes
 checkout_ensembl_branch parasite-static master EnsemblGenomes
 checkout_ensembl_branch eg-web-common master EnsemblGenomes
-
-
+checkout_ensembl_branch ensembl-production-imported trunk
+checkout_ensembl_branch ensembl-production-imported-private trunk
 


### PR DESCRIPTION
eg-pipelines repo is now deprecated and replaced by ensembl-production-imported (modules) and ensembl-production-imported-private (config).